### PR TITLE
Adding a soft delete query flag to disable softdelete queries

### DIFF
--- a/lib/sqlalchemy_softdelete/softdelete.py
+++ b/lib/sqlalchemy_softdelete/softdelete.py
@@ -12,11 +12,11 @@ class SoftDeleteSession(Session):
         kwargs['enable_baked_queries'] = False
         self._super.__init__(query_cls=SoftDeleteQuery, *args, **kwargs)
         # Flag allowing you to disable the soft delete query.
-        self.disableSoftDeleteQuery = False
+        self.disable_soft_delete_query = False
 
     def query(self, *entities, **kwargs):
         return super(SoftDeleteSession, self).query(*entities, **kwargs) \
-            if not self.disableSoftDeleteQuery else Query(entities, self, **kwargs)
+            if not self.disable_soft_delete_query else Query(entities, self, **kwargs)
 
     def delete(self, instance, *args, **kwargs):
         if isinstance(instance, SoftDeletable):

--- a/lib/sqlalchemy_softdelete/softdelete.py
+++ b/lib/sqlalchemy_softdelete/softdelete.py
@@ -16,7 +16,7 @@ class SoftDeleteSession(Session):
 
     def query(self, *entities, **kwargs):
         return super(SoftDeleteSession, self).query(*entities, **kwargs) \
-            if not self.disableSoftDeleteQuery else Query(*entities, self, **kwargs)
+            if not self.disableSoftDeleteQuery else Query(entities, self, **kwargs)
 
     def delete(self, instance, *args, **kwargs):
         if isinstance(instance, SoftDeletable):

--- a/lib/sqlalchemy_softdelete/softdelete.py
+++ b/lib/sqlalchemy_softdelete/softdelete.py
@@ -11,9 +11,12 @@ class SoftDeleteSession(Session):
         self._super = super(SoftDeleteSession, self)
         kwargs['enable_baked_queries'] = False
         self._super.__init__(query_cls=SoftDeleteQuery, *args, **kwargs)
+        # Flag allowing you to disable the soft delete query.
+        self.disableSoftDeleteQuery = False
 
-    def query(self, *args, **kwargs):
-        return super(SoftDeleteSession, self).query(*args, **kwargs)
+    def query(self, *entities, **kwargs):
+        return super(SoftDeleteSession, self).query(*entities, **kwargs) \
+            if not self.disableSoftDeleteQuery else Query(*entities, self, **kwargs)
 
     def delete(self, instance, *args, **kwargs):
         if isinstance(instance, SoftDeletable):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sqlalchemy_softdelete",
-    version="0.2",
+    version="1.1",
     url="http://github.com/mattias-lidman/sqlalchemy_softdelete",
     license="BSD",
     description="Soft deletes in SQLAlchemy",

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="sqlalchemy_softdelete",
-    version="0.1",
+    version="0.2",
     url="http://github.com/mattias-lidman/sqlalchemy_softdelete",
     license="BSD",
     description="Soft deletes in SQLAlchemy",


### PR DESCRIPTION
In some use-cases we would like to override the softdelete query. This flag allows that to be done.

The intention is solely to allow temporary modification of generated queries, note that it may have unintended side effects if used beyond that use-case.